### PR TITLE
Bugfix for format block in templates

### DIFF
--- a/ses_mailer.py
+++ b/ses_mailer.py
@@ -253,7 +253,7 @@ class Mail(object):
         }
         for ob in optional_blocks:
             if ob in blocks:
-                if ob == "format" and mail_params[ob].lower() not in ["html", "text"]:
+                if ob == "format" and blocks[ob].lower() not in ["html", "text"]:
                     continue
                 mail_params[ob] = blocks[ob]
         return mail_params


### PR DESCRIPTION
Fixes bug where we look for "format" in mail_data before it's been inserted. We really want to access blocks['format'].